### PR TITLE
Fix import of non-default export

### DIFF
--- a/src/verifyAttestation.js
+++ b/src/verifyAttestation.js
@@ -1,7 +1,7 @@
 import cbor from 'cbor';
 import { createHash, X509Certificate } from 'crypto';
-import asn1js from 'asn1js';
-import pkijs from 'pkijs';
+import * as asn1js from 'asn1js';
+import * as pkijs from 'pkijs';
 
 // eslint-disable-next-line max-len
 const APPLE_APP_ATTESTATION_ROOT_CA = new X509Certificate('-----BEGIN CERTIFICATE-----\nMIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYwJAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwKQXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNaFw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlvbiBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9ybmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdhNbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9auYen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYwCgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijVoyFraWVIyd/dganmrduC1bmTBGwD\n-----END CERTIFICATE-----');


### PR DESCRIPTION
When trying to use this package in a Cloudflare Worker (in Node.js compatibility mode), I got the following error when trying to build my worker:

```
 ✘ [ERROR] No matching export in
  "node_modules/asn1js/build/index.es.js" for import "default"
  
      node_modules/node-app-attest/src/verifyAttestation.js:3:7:
        3 │ import asn1js from 'asn1js';
```

And the same for the import of `pkijs` on line 4. There seems to be no default export in these libraries, so we need to import them another way.